### PR TITLE
Allow attribute extensions

### DIFF
--- a/lib/ethos/attributes.rb
+++ b/lib/ethos/attributes.rb
@@ -34,7 +34,13 @@ module Ethos
 
     def [](key)
       memoize key do
-        current[key] and Ethos::Type.cast current[key], schema.attributes[key][:type]
+        value = Ethos::Type.cast current[key], schema.attributes[key][:type]
+
+        schema.attributes[key][:extensions].each do |extension|
+          value.instance_eval &extension
+        end
+
+        value
       end
     end
 

--- a/lib/ethos/entity.rb
+++ b/lib/ethos/entity.rb
@@ -8,8 +8,8 @@ module Ethos
         @_schema ||= Ethos::Schema.new
       end
 
-      def attribute(key, type, default: nil)
-        schema.define key, type, default: default
+      def attribute(key, type, default: nil, &extension)
+        schema.define key, type, default: default, extensions: [extension].compact
 
         reader = :"#{key}"
         writer = :"#{key}="

--- a/lib/ethos/schema.rb
+++ b/lib/ethos/schema.rb
@@ -8,10 +8,11 @@ module Ethos
       @_defaults ||= {}
     end
 
-    def define(key, type, default: nil)
+    def define(key, type, default: nil, extensions: [])
       attributes[key] = {
         type: type,
-        default: default
+        default: default,
+        extensions: extensions
       }
 
       defaults[key] = default if default

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -71,6 +71,26 @@ scope do
     class Entity
       prepend Ethos::Entity
 
+      attribute :value, String do
+        def extended?
+          true
+        end
+      end
+    end
+  end
+
+  spec do
+    entity = Entity.new
+
+    asserts(entity.value).extended?
+  end
+end
+
+scope do
+  setup do
+    class Entity
+      prepend Ethos::Entity
+
       attribute :name, String
       attribute :parent, Entity
     end

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -84,6 +84,12 @@ scope do
 
     asserts(entity.value).extended?
   end
+
+  spec do
+    entity = Entity.new value: '1'
+
+    asserts(entity.value).extended?
+  end
 end
 
 scope do

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -90,6 +90,14 @@ scope do
 
     asserts(entity.value).extended?
   end
+
+  spec do
+    entity = Entity.new
+
+    entity.value = '1'
+
+    asserts(entity.value).extended?
+  end
 end
 
 scope do

--- a/spec/ethos/schema.rb
+++ b/spec/ethos/schema.rb
@@ -8,7 +8,7 @@ scope do
   end
 
   spec do
-    asserts(schema.attributes[:value]) == {type: Integer, default: nil}
+    asserts(schema.attributes[:value]) == {type: Integer, default: nil, extensions: []}
   end
 
   spec do
@@ -22,7 +22,7 @@ scope do
   end
 
   spec do
-    asserts(schema.attributes[:value]) == {type: Integer, default: 1}
+    asserts(schema.attributes[:value]) == {type: Integer, default: 1, extensions: []}
   end
 
   spec do


### PR DESCRIPTION
```
class Entity
  prepend Ethos::Entity

  attribute :value, String do
    def words
      self.split(/\W+/)
    end
  end
end

entity = Entity.new value: 'a b c'
entity.value.words #=> ['a', 'b', 'c']
```