### PR TITLE
Add read-only collections

### DIFF
--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -1,0 +1,4 @@
+module Ethos
+  class Collection
+  end
+end

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -11,5 +11,9 @@ module Ethos
     def initialize(values)
       @_values = values
     end
+
+    def size
+      @_values.size
+    end
   end
 end

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -1,4 +1,11 @@
 module Ethos
   class Collection
+    def self.type=(type)
+      @_type = type
+    end
+
+    def self.type
+      @_type
+    end
   end
 end

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -1,10 +1,10 @@
 module Ethos
   class Collection
-    def self.type=(type)
+    def type=(type)
       @_type = type
     end
 
-    def self.type
+    def type
       @_type
     end
 

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -15,5 +15,14 @@ module Ethos
     def size
       @_values.size
     end
+
+    def ==(other)
+      return false unless other.is_a? self.class
+      return false unless self.size == other.size
+
+      not size.times.any? do |i|
+        self[i] != other[i]
+      end
+    end
   end
 end

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -16,6 +16,12 @@ module Ethos
       @_values.size
     end
 
+    def [](index)
+      memoize index do
+        Ethos::Type.cast @_values[index], type
+      end
+    end
+
     def ==(other)
       return false unless other.is_a? self.class
       return false unless self.size == other.size
@@ -23,6 +29,22 @@ module Ethos
       not size.times.any? do |i|
         self[i] != other[i]
       end
+    end
+
+    private
+
+    def memoized
+      @_memoized ||= []
+    end
+
+    def memoize(index)
+      return memoized[index] if memoized[index]
+
+      memoized[index] = yield
+    end
+
+    def unmemoize(index)
+      memoized[index] = nil
     end
   end
 end

--- a/lib/ethos/collection.rb
+++ b/lib/ethos/collection.rb
@@ -7,5 +7,9 @@ module Ethos
     def self.type
       @_type
     end
+
+    def initialize(values)
+      @_values = values
+    end
   end
 end

--- a/lib/ethos/entity.rb
+++ b/lib/ethos/entity.rb
@@ -1,5 +1,6 @@
 require 'ethos/schema'
 require 'ethos/attributes'
+require 'ethos/collection'
 
 module Ethos
   module Entity
@@ -21,6 +22,13 @@ module Ethos
         define_method writer do |value|
           attributes[key] = value
         end
+      end
+
+      def collection(key, type)
+        klass = Class.new Ethos::Collection
+        klass.type = type
+
+        attribute key, klass, default: []
       end
     end
 

--- a/lib/ethos/entity.rb
+++ b/lib/ethos/entity.rb
@@ -25,10 +25,9 @@ module Ethos
       end
 
       def collection(key, type)
-        klass = Class.new Ethos::Collection
-        klass.type = type
+        attribute key, Ethos::Collection, default: []
 
-        attribute key, klass, default: []
+        schema.attributes[key][:extensions].push Proc.new { self.type = type }
       end
     end
 

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -136,6 +136,33 @@ scope do
     class Entity
       prepend Ethos::Entity
 
+      attribute :name, String
+      collection :children, Entity
+    end
+  end
+
+  scope do
+    define entity: -> { Entity.new }
+
+    spec do
+      asserts(entity.children.size) == 0
+    end
+  end
+
+  scope do
+    define entity: -> { Entity.new children: [{name: 'Child'}] }
+
+    spec do
+      asserts(entity.children.size) == 1
+    end
+  end
+end
+
+scope do
+  setup do
+    class Entity
+      prepend Ethos::Entity
+
       attribute :value, Integer
     end
   end

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -150,10 +150,22 @@ scope do
   end
 
   scope do
-    define entity: -> { Entity.new children: [{name: 'Child'}] }
+    define entity: -> { Entity.new children: [{name: 'Child 1'}, {name: 'Child 2'}] }
 
     spec do
-      asserts(entity.children.size) == 1
+      asserts(entity.children.size) == 2
+    end
+
+    spec do
+      expected = Entity.new name: 'Child 1'
+
+      asserts(entity.children[0]) == expected
+    end
+
+    spec do
+      expected = Entity.new name: 'Child 2'
+
+      asserts(entity.children[1]) == expected
     end
   end
 end


### PR DESCRIPTION
This partially addresses #17. Collections are read-only for now and can only be set at initialization.

```
class Entity
  attribute :name, String
  collection :children, Entity
end

entity.new = Entity.new name: 'Parent', children: [{name: 'Child 1'}, {name: 'Child 2'}]
```