### PR TITLE
Cast to an instance of a type specified by a string

### DIFF
--- a/lib/ethos/type.rb
+++ b/lib/ethos/type.rb
@@ -13,6 +13,8 @@ module Ethos
     def self.cast(value, type)
       return value if value.nil?
 
+      type = Module.const_get type if type.is_a? String
+
       return value if value.is_a? type
 
       return CASTS[type][value] if CASTS.key? type

--- a/spec/ethos/type.rb
+++ b/spec/ethos/type.rb
@@ -90,6 +90,13 @@ scope '.cast' do
     asserts(result.value) == expected.value
   end
 
+  spec 'casts to an instance of a type specified by a string' do
+    expected = 1.0
+    result = Ethos::Type.cast '1', 'Float'
+
+    asserts(result) == expected
+  end
+
   spec 'casts a nil' do
     class Entity
       prepend Ethos::Entity


### PR DESCRIPTION
Use strings to allow lazy-evaluation of classes when specifying types:

```
class Entity
  attribute :value, 'Integer'
end
```