### PR TITLE
Allow mass-assignment

### DIFF
--- a/lib/ethos/entity.rb
+++ b/lib/ethos/entity.rb
@@ -41,6 +41,10 @@ module Ethos
       super()
     end
 
+    def attributes=(values)
+      @_attributes = Ethos::Attributes.new self.class.schema, values: values
+    end
+
     def attributes
       @_attributes
     end

--- a/lib/ethos/entity.rb
+++ b/lib/ethos/entity.rb
@@ -36,7 +36,7 @@ module Ethos
     end
 
     def initialize(values = {})
-      @_attributes = Ethos::Attributes.new self.class.schema, values: values
+      self.attributes = values
 
       super()
     end

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -26,6 +26,13 @@ scope do
 
     asserts(entity.value) == 1
   end
+
+  spec do
+    entity = Entity.new
+    entity.attributes = {value: 1}
+
+    asserts(entity.value) == 1
+  end
 end
 
 scope do

--- a/spec/ethos/entity.rb
+++ b/spec/ethos/entity.rb
@@ -55,6 +55,20 @@ scope do
 
     asserts(entity.value) == 2
   end
+
+  spec do
+    entity = Entity.new
+    entity.attributes = {value: 2}
+
+    asserts(entity.value) == 2
+  end
+
+  spec do
+    entity = Entity.new
+    entity.attributes = {}
+
+    asserts(entity.value) == 1
+  end
 end
 
 scope do


### PR DESCRIPTION
Let's allow mass-assignment:

```ruby
class Person
  prepend Ethos::Entity

  attribute :firstname, String
  attribute :lastname, String
end

person = Person.new
person.attributes = {firstname: 'John', lastname: 'Doe'}
```